### PR TITLE
Enable the API Explorer by default

### DIFF
--- a/boot-update-config.sh
+++ b/boot-update-config.sh
@@ -19,3 +19,6 @@ perl -pi -e "s%GSSAPIAuthentication yes%GSSAPIAuthentication no%" /etc/ssh/sshd_
 
 # Set APC Cache to 128M instead of only 64
 sed -i "s/^apc.shm_size=.*$/apc.shm_size=128M/" /etc/php.d/apc.ini
+
+# Enable API Explorer
+ln -sf /usr/share/restler/vendor/Luracast/Restler/explorer/ /usr/share/tuleap/src/www/api/explorer


### PR DESCRIPTION
It seems reasonable that in a dev setup the API Explorer is enabled.