### PR TITLE
Ease the usage of a debugger in a development environnement

### DIFF
--- a/xdebug.ini
+++ b/xdebug.ini
@@ -8,3 +8,6 @@ xdebug.var_display_max_depth=10
 xdebug.profiler_enable_trigger=1
 xdebug.profiler_output_dir="/data/var/lib/cachegrind"
 xdebug.profiler_output_name="cachegrind.out.%s.%r"
+
+xdebug.remote_connect_back=1
+xdebug.remote_enable=1


### PR DESCRIPTION
The proposed XDebug configuration is quite permissive to make
the configuration of your dev tools easy. Your dev instance is not
supposed to be exposed to untrusted users.