### PR TITLE
Ease debugguer usage with PHP 5.6 FPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ RUN localedef -i fr_FR -c -f UTF-8 fr_FR.UTF-8
 
 COPY supervisord.conf /etc/supervisord.conf
 COPY xdebug.ini /etc/php.d/xdebug.ini
+COPY xdebug-fpm.ini /etc/opt/rh/rh-php56/php.d/15-xdebug.ini
 
 COPY . /root/app
 

--- a/xdebug-fpm.ini
+++ b/xdebug-fpm.ini
@@ -1,0 +1,13 @@
+; Enable xdebug extension module
+zend_extension=xdebug.so
+
+xdebug.max_nesting_level=200
+
+xdebug.var_display_max_depth=10
+;xdebug.profiler_enable=1
+xdebug.profiler_enable_trigger=1
+xdebug.profiler_output_dir="/data/var/lib/cachegrind"
+xdebug.profiler_output_name="cachegrind.out.%s.%r"
+
+xdebug.remote_connect_back=1
+xdebug.remote_enable=1


### PR DESCRIPTION
This contribution is similar to what has been done for PHP 5.3
in commit 6a8d79748e7e7ce7e053bf079767b92531e48f75 but for PHP 5.6