### PR TITLE
Replace launch_system_check.php by 'tuleap queue-system-check'

### DIFF
--- a/boot-install.sh
+++ b/boot-install.sh
@@ -42,7 +42,7 @@ echo "root: $root_passwd" >> /root/.tuleap_passwd
 touch /etc/aliases.codendi
 
 # Ensure system will be synchronized ASAP
-/usr/share/tuleap/src/utils/php-launcher.sh /usr/share/tuleap/src/utils/launch_system_check.php
+/usr/bin/tuleap queue-system-check
 
 service httpd stop
 service crond stop

--- a/boot-upgrade.sh
+++ b/boot-upgrade.sh
@@ -10,4 +10,4 @@ else
 fi
 
 # Ensure system will be synchronized ASAP (once system starts)
-/usr/share/tuleap/src/utils/php-launcher.sh /usr/share/tuleap/src/utils/launch_system_check.php
+/usr/bin/tuleap queue-system-check


### PR DESCRIPTION
Part of [request #13683](https://tuleap.net/plugins/tracker/?aid=13683): Distributed Tuleap integration tests can not be executed