### PR TITLE
Pull-in LDAP dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
     tuleap-plugin-svn \
     tuleap-plugin-hudson\* \
     tuleap-plugin-mediawiki \
+    tuleap-plugin-ldap \
     tuleap-api-explorer \
     java-1.8.0-openjdk \
     openldap-clients \


### PR DESCRIPTION
Development environment are LDAP based but we do not pull all the needed
dependencies.