### PR TITLE
Add develop in xdebug.mode

### DIFF
--- a/xdebug-fpm.ini
+++ b/xdebug-fpm.ini
@@ -12,5 +12,5 @@ xdebug.profiler_output_name="cachegrind.out.%s.%r"
 xdebug.remote_connect_back=1
 xdebug.remote_enable=1
 
-xdebug.mode=debug
+xdebug.mode=debug,develop
 xdebug.discover_client_host=1


### PR DESCRIPTION
So that we have "nice" stack trackes and var dump by default.