### PR TITLE
No longer need to override tuleap-php-fpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ STOPSIGNAL SIGRTMIN+3
 COPY remi-safe.repo /etc/yum.repos.d/
 COPY RPM-GPG-KEY-remi /etc/pki/rpm-gpg/
 COPY Tuleap.repo /etc/yum.repos.d/
-COPY tuleap-php-fpm-override.conf /etc/systemd/system/tuleap-php-fpm.service.d/override.conf
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
     systemd-tmpfiles-setup.service ] || rm -f $i; done); \

--- a/tuleap-php-fpm-override.conf
+++ b/tuleap-php-fpm-override.conf
@@ -1,8 +1,0 @@
-[Unit]
-Conflicts=php74-php-fpm.service php80-php-fpm.service
-
-[Service]
-PIDFile=/var/opt/remi/php80/run/php-fpm/php-fpm.pid
-EnvironmentFile=/etc/opt/remi/php80/sysconfig/php-fpm
-ExecStart=
-ExecStart=/opt/remi/php80/root/usr/sbin/php-fpm --nodaemonize


### PR DESCRIPTION
This was needed during the transition between php 7.4 and php 8.0
but as tuleap packages now ships with php 8.0 there is no longer
conflicts.

Morever we should be able to start php 7.4 because it will be required
for Mediawiki 1.35