### PR TITLE
Add MediaWiki standalone dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
     tuleap-plugin-svn \
     tuleap-plugin-hudson\* \
     tuleap-plugin-mediawiki \
+    tuleap-plugin-mediawiki-standalone \
     tuleap-plugin-ldap \
     tuleap-api-explorer \
     java-1.8.0-openjdk \


### PR DESCRIPTION
This make easier to test the MediaWiki Standalone plugin: all dependencies are installed and Systemd unit is deployed.

Part of [story #26042](https://tuleap.net/plugins/tracker/?aid=26042): install mediawiki standalone