### PR TITLE
Add less

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
     java-1.8.0-openjdk \
     openldap-clients \
     vim \
+    less \
     php80-php-intl \
     php80-php-bcmath \
     php80-php-gd \


### PR DESCRIPTION
less used to be the default pager on RHEL/CentOS but now it
seems that only more is available by default.

Let's keep the good old habits.