### PR TITLE
Enable dependabot for github actions also on el9 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+- package-ecosystem: "github-actions"
+  directory: "/"
+  target-branch: "el9-php82"
+  schedule:
+    interval: daily


### PR DESCRIPTION
Dependabot only updates the default branch otherwise.