### PR TITLE
fix: Add the MySQL CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/*;\
     java-1.8.0-openjdk \
     openldap-clients \
     vim \
+    mysql \
     less \
     php82-php-intl \
     php82-php-bcmath \


### PR DESCRIPTION
It still has some uses in dev scenario and it is currently needed by the init script.

Part of request #35879 Remove dependency to MySQL CLI tools