### PR TITLE
fix: Add the PR plugin to the image

### DIFF
--- a/el9.dockerfile
+++ b/el9.dockerfile
@@ -35,6 +35,7 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/*;\
     tuleap-theme-flamingparrot \
     tuleap-plugin-git \
     tuleap-plugin-gitlfs \
+    tuleap-plugin-pullrequest \
     tuleap-plugin-svn \
     tuleap-plugin-hudson\* \
     tuleap-plugin-mediawiki \


### PR DESCRIPTION
This will deploy the sudoers file that is deployed by the packaging.

Part of request #45992 Manage Git repositories without relying on SSHd